### PR TITLE
Fix type annotation on Python 3.8

### DIFF
--- a/openopc2/cli.py
+++ b/openopc2/cli.py
@@ -87,7 +87,7 @@ def get_connected_da_client(
 
 @app.command()
 def read(
-        tags: list[str] = TagsArgument,
+        tags: List[str] = TagsArgument,
         protocol_mode: ProtocolMode = ProtocolModeOption,
         opc_server: str = OpcServerOption,
         opc_host: str = OpcHostOption,
@@ -113,7 +113,7 @@ def read(
         gateway_host,
         gateway_port
     )
-    responses: list[str] = client.read(tags,
+    responses: List[str] = client.read(tags,
                                        group='test',
                                        size=group_size,
                                        pause=pause,
@@ -140,7 +140,7 @@ def read(
 
 @app.command()
 def write(
-        tag_value_pairs: list[str] = TagValuePairsArgument,
+        tag_value_pairs: List[str] = TagValuePairsArgument,
         protocol_mode: ProtocolMode = ProtocolModeOption,
         opc_server: str = OpcServerOption,
         opc_host: str = OpcHostOption,
@@ -157,7 +157,7 @@ def write(
     log.setLevel(log_level.upper())
 
     # Validate and transform tag value pairs
-    tag_values: list[Tuple[str, str]] = []
+    tag_values: List[Tuple[str, str]] = []
     try:
         for tag in tag_value_pairs:
             tag_values.append(tuple(tag.split('=')))
@@ -167,7 +167,7 @@ def write(
 
     try:
         print(f"Writing {len(tag_values)} value(s)...")
-        responses: list[Tuple[str, str]] = get_connected_da_client(
+        responses: List[Tuple[str, str]] = get_connected_da_client(
             protocol_mode,
             opc_server,
             opc_host,
@@ -254,7 +254,7 @@ def list_tags(
 
 @app.command()
 def properties(
-        tags: list[str] = TagsArgument,
+        tags: List[str] = TagsArgument,
         protocol_mode: ProtocolMode = ProtocolModeOption,
         opc_server: str = OpcServerOption,
         opc_host: str = OpcHostOption,
@@ -266,7 +266,7 @@ def properties(
     Show properties of given tags
     """
     log.setLevel(log_level.upper())
-    properties: list[Tuple[int, str, Any]] = get_connected_da_client(
+    properties: List[Tuple[int, str, Any]] = get_connected_da_client(
         protocol_mode,
         opc_server,
         opc_host,

--- a/openopc2/opc_types.py
+++ b/openopc2/opc_types.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from dataclasses import dataclass, asdict
+from typing import Dict
 from enum import Enum
 
 
@@ -62,7 +63,7 @@ class TagProperties:
     eu_info: str = None
     description: str = None
 
-    def from_tag_property_items_by_name(self, tag, tag_property_items_by_name: dict[TagPropertyItem]):
+    def from_tag_property_items_by_name(self, tag, tag_property_items_by_name: Dict[str, TagPropertyItem]):
         default_property_item = TagPropertyItem()
         self.tag_name = tag
         self.data_type = tag_property_items_by_name.get('Item Canonical DataType', default_property_item).value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openopc2"
-version = "0.1.3"
+version = "0.1.4"
 description = "OPC library with a Windows gateway enabling non-Windows clients to access OPC-DA calls."
 license = "GPL-2.0-or-later"
 readme = "README.md"


### PR DESCRIPTION
This should fix type annotation problems occurring with Python 3.8 due to lacking support of using native types for type annotations