### PR TITLE
Docs Fixes and Formatting

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -8,22 +8,22 @@ $ openopc2 CLI [OPTIONS] COMMAND [ARGS]...
 
 **Options**:
 
-* `--install-completion`: Install completion for the current shell.
-* `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
-* `--help`: Show this message and exit.
+- `--install-completion`: Install completion for the current shell.
+- `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
+- `--help`: Show this message and exit.
 
 **Commands**:
 
-* `list-clients`: [EXPERIMENTAL] List clients of OpenOPC...
-* `list-tags`: List tags (items) of OPC server
-* `properties`: Show properties of given tags
-* `read`: Read tags
-* `server-info`: Display OPC server information
-* `write`: Write values
+- `list-clients`: \[EXPERIMENTAL\] List clients of OpenOPC...
+- `list-tags`: List tags (items) of OPC server
+- `properties`: Show properties of given tags
+- `read`: Read tags
+- `server-info`: Display OPC server information
+- `write`: Write values
 
 ## `openopc2 CLI list-clients`
 
-[EXPERIMENTAL] List clients of OpenOPC Gateway Server
+\[EXPERIMENTAL\] List clients of OpenOPC Gateway Server
 
 **Usage**:
 
@@ -33,8 +33,8 @@ $ openopc2 CLI list-clients [OPTIONS]
 
 **Options**:
 
-* `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  [default: WARNING]
-* `--help`: Show this message and exit.
+- `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  \[default: WARNING\]
+- `--help`: Show this message and exit.
 
 ## `openopc2 CLI list-tags`
 
@@ -48,15 +48,15 @@ $ openopc2 CLI list-tags [OPTIONS]
 
 **Options**:
 
-* `--protocol-mode [com|gateway]`: Protocol mode  [default: gateway]
-* `--opc-server TEXT`: OPC Server to connect to  [default: Matrikon.OPC.Simulation]
-* `--opc-host TEXT`: OPC Host to connect to  [default: localhost]
-* `--gateway-host TEXT`: OPC Gateway Host to connect to  [default: 192.168.0.115]
-* `--gateway-port INTEGER`: OPC Gateway Port to connect to  [default: 7766]
-* `--recursive / --no-recursive`: Recursively read sub-tags  [default: False]
-* `--output-csv / --no-output-csv`: Output in CSV format  [default: False]
-* `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  [default: WARNING]
-* `--help`: Show this message and exit.
+- `--protocol-mode [com|gateway]`: Protocol mode  \[default: gateway\]
+- `--opc-server TEXT`: OPC Server to connect to  \[default: Matrikon.OPC.Simulation\]
+- `--opc-host TEXT`: OPC Host to connect to  \[default: localhost\]
+- `--gateway-host TEXT`: OPC Gateway Host to connect to  \[default: 192.168.0.115\]
+- `--gateway-port INTEGER`: OPC Gateway Port to connect to  \[default: 7766\]
+- `--recursive / --no-recursive`: Recursively read sub-tags  \[default: False\]
+- `--output-csv / --no-output-csv`: Output in CSV format  \[default: False\]
+- `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  \[default: WARNING\]
+- `--help`: Show this message and exit.
 
 ## `openopc2 CLI properties`
 
@@ -70,17 +70,17 @@ $ openopc2 CLI properties [OPTIONS] TAGS...
 
 **Arguments**:
 
-* `TAGS...`: Tags to read  [required]
+- `TAGS...`: Tags to read  \[required\]
 
 **Options**:
 
-* `--protocol-mode [com|gateway]`: Protocol mode  [default: gateway]
-* `--opc-server TEXT`: OPC Server to connect to  [default: Matrikon.OPC.Simulation]
-* `--opc-host TEXT`: OPC Host to connect to  [default: localhost]
-* `--gateway-host TEXT`: OPC Gateway Host to connect to  [default: 192.168.0.115]
-* `--gateway-port INTEGER`: OPC Gateway Port to connect to  [default: 7766]
-* `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  [default: WARNING]
-* `--help`: Show this message and exit.
+- `--protocol-mode [com|gateway]`: Protocol mode  \[default: gateway\]
+- `--opc-server TEXT`: OPC Server to connect to  \[default: Matrikon.OPC.Simulation\]
+- `--opc-host TEXT`: OPC Host to connect to  \[default: localhost\]
+- `--gateway-host TEXT`: OPC Gateway Host to connect to  \[default: 192.168.0.115\]
+- `--gateway-port INTEGER`: OPC Gateway Port to connect to  \[default: 7766\]
+- `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  \[default: WARNING\]
+- `--help`: Show this message and exit.
 
 ## `openopc2 CLI read`
 
@@ -94,24 +94,24 @@ $ openopc2 CLI read [OPTIONS] TAGS...
 
 **Arguments**:
 
-* `TAGS...`: Tags to read  [required]
+- `TAGS...`: Tags to read  \[required\]
 
 **Options**:
 
-* `--protocol-mode [com|gateway]`: Protocol mode  [default: gateway]
-* `--opc-server TEXT`: OPC Server to connect to  [default: Matrikon.OPC.Simulation]
-* `--opc-host TEXT`: OPC Host to connect to  [default: localhost]
-* `--gateway-host TEXT`: OPC Gateway Host to connect to  [default: 192.168.0.115]
-* `--gateway-port INTEGER`: OPC Gateway Port to connect to  [default: 7766]
-* `--group-size INTEGER`: Group tags into group_size tags per transaction
-* `--pause INTEGER`: Sleep time between transactionsin milliseconds  [default: 0]
-* `--source [cache|device|hybrid]`: Data SOURCE for reads (cache, device, hybrid)  [default: hybrid]
-* `--update-rate INTEGER`: Update rate for group in milliseconds  [default: 0]
-* `--timeout INTEGER`: Read timeout in milliseconds  [default: 10000]
-* `--include-error-messages / --no-include-error-messages`: Include descriptive error message strings  [default: False]
-* `--output-csv / --no-output-csv`: Output in CSV format  [default: False]
-* `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  [default: WARNING]
-* `--help`: Show this message and exit.
+- `--protocol-mode [com|gateway]`: Protocol mode  \[default: gateway\]
+- `--opc-server TEXT`: OPC Server to connect to  \[default: Matrikon.OPC.Simulation\]
+- `--opc-host TEXT`: OPC Host to connect to  \[default: localhost\]
+- `--gateway-host TEXT`: OPC Gateway Host to connect to  \[default: 192.168.0.115\]
+- `--gateway-port INTEGER`: OPC Gateway Port to connect to  \[default: 7766\]
+- `--group-size INTEGER`: Group tags into group_size tags per transaction
+- `--pause INTEGER`: Sleep time between transactionsin milliseconds  \[default: 0\]
+- `--source [cache|device|hybrid]`: Data SOURCE for reads (cache, device, hybrid)  \[default: hybrid\]
+- `--update-rate INTEGER`: Update rate for group in milliseconds  \[default: 0\]
+- `--timeout INTEGER`: Read timeout in milliseconds  \[default: 10000\]
+- `--include-error-messages / --no-include-error-messages`: Include descriptive error message strings  \[default: False\]
+- `--output-csv / --no-output-csv`: Output in CSV format  \[default: False\]
+- `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  \[default: WARNING\]
+- `--help`: Show this message and exit.
 
 ## `openopc2 CLI server-info`
 
@@ -125,13 +125,13 @@ $ openopc2 CLI server-info [OPTIONS]
 
 **Options**:
 
-* `--protocol-mode [com|gateway]`: Protocol mode  [default: gateway]
-* `--opc-server TEXT`: OPC Server to connect to  [default: Matrikon.OPC.Simulation]
-* `--opc-host TEXT`: OPC Host to connect to  [default: localhost]
-* `--gateway-host TEXT`: OPC Gateway Host to connect to  [default: 192.168.0.115]
-* `--gateway-port INTEGER`: OPC Gateway Port to connect to  [default: 7766]
-* `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  [default: WARNING]
-* `--help`: Show this message and exit.
+- `--protocol-mode [com|gateway]`: Protocol mode  \[default: gateway\]
+- `--opc-server TEXT`: OPC Server to connect to  \[default: Matrikon.OPC.Simulation\]
+- `--opc-host TEXT`: OPC Host to connect to  \[default: localhost\]
+- `--gateway-host TEXT`: OPC Gateway Host to connect to  \[default: 192.168.0.115\]
+- `--gateway-port INTEGER`: OPC Gateway Port to connect to  \[default: 7766\]
+- `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  \[default: WARNING\]
+- `--help`: Show this message and exit.
 
 ## `openopc2 CLI write`
 
@@ -145,17 +145,17 @@ $ openopc2 CLI write [OPTIONS] TAG_VALUE_PAIRS...
 
 **Arguments**:
 
-* `TAG_VALUE_PAIRS...`: Tag value pairs to write (use ITEM,VALUE)  [required]
+- `TAG_VALUE_PAIRS...`: Tag value pairs to write (use ITEM,VALUE)  \[required\]
 
 **Options**:
 
-* `--protocol-mode [com|gateway]`: Protocol mode  [default: gateway]
-* `--opc-server TEXT`: OPC Server to connect to  [default: Matrikon.OPC.Simulation]
-* `--opc-host TEXT`: OPC Host to connect to  [default: localhost]
-* `--gateway-host TEXT`: OPC Gateway Host to connect to  [default: 192.168.0.115]
-* `--gateway-port INTEGER`: OPC Gateway Port to connect to  [default: 7766]
-* `--group-size INTEGER`: Group tags into group_size tags per transaction
-* `--pause INTEGER`: Sleep time between transactionsin milliseconds  [default: 0]
-* `--include-error-messages / --no-include-error-messages`: Include descriptive error message strings  [default: False]
-* `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  [default: WARNING]
-* `--help`: Show this message and exit.
+- `--protocol-mode [com|gateway]`: Protocol mode  \[default: gateway\]
+- `--opc-server TEXT`: OPC Server to connect to  \[default: Matrikon.OPC.Simulation\]
+- `--opc-host TEXT`: OPC Host to connect to  \[default: localhost\]
+- `--gateway-host TEXT`: OPC Gateway Host to connect to  \[default: 192.168.0.115\]
+- `--gateway-port INTEGER`: OPC Gateway Port to connect to  \[default: 7766\]
+- `--group-size INTEGER`: Group tags into group_size tags per transaction
+- `--pause INTEGER`: Sleep time between transactionsin milliseconds  \[default: 0\]
+- `--include-error-messages / --no-include-error-messages`: Include descriptive error message strings  \[default: False\]
+- `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Log level  \[default: WARNING\]
+- `--help`: Show this message and exit.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -121,8 +121,8 @@ https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
 
-[homepage]: https://www.contributor-covenant.org
-
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at
 https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You must install the gbda_aut.dll (in /lib) which is the GrayboxOpcDa wrapper.
 http://gray-box.net/daawrapper.php?lang=en
 
 ```console
-python -m openopc2 servers
+python -m openopc2 list-servers
 ```
 
 ## Multi platform installation
@@ -82,7 +82,7 @@ openopcservice start
 
 On your Linux machine
 
-```
+```shell
 pip install openopc2
 ```
 
@@ -106,13 +106,16 @@ OPC_MODE=dcom
 OPC_SERVER=Matrikon.OPC.Simulation
 ```
 
-- If they are not set, open a command prompt window to do that by
-  typing:
+- If they are not set, open a command prompt window (`cmd`) and type:
 
 ```
 C:\>set ENV_VAR=VALUE
 C:\>set OPC_GATE_HOST=172.16.4.22    # this is an example
 ```
+
+- Alternately, Windows OS system or user environment variables work.
+  Note that user environment variables take precedent over system environment
+  variables.
 
 - Make sure the firewall is allowed to keep the port 7766 open. If in
   doubt, and you're doing a quick test, just turn off your firewall

--- a/README.md
+++ b/README.md
@@ -2,69 +2,60 @@
 <img src="https://github.com/iterativ/openopc2/raw/develop/doc/assets/open-opc.png" alt="LinuxSetup" width="700"/>
 </p>
 
-
 [![PyPI version](https://badge.fury.io/py/openopc2.svg)](https://badge.fury.io/py/openopc2)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/openopc2)
 
-
-
 **OpenOPC 2**  is a Python Library for OPC DA. It is Open source and free for everyone. It allows you to use
-[OPC Classic](https://opcfoundation.org/about/opc-technologies/opc-classic/) (OPC Data Access) in 
+[OPC Classic](https://opcfoundation.org/about/opc-technologies/opc-classic/) (OPC Data Access) in
 modern Python environments. OPC Classic is a pure Windows technology by design, but this library includes a Gateway Server
-that lets you use OPC Classic on any architecture (Linux, MacOS, Windows, Docker). So this Library creates a gateway 
-between 2022 and the late 90ties. Like cruising into the sunset with Marty McFly in a Tesla. 
+that lets you use OPC Classic on any architecture (Linux, MacOS, Windows, Docker). So this Library creates a gateway
+between 2022 and the late 90ties. Like cruising into the sunset with Marty McFly in a Tesla.
 
 OpenOPC 2 is based on the OpenOPC Library that was initially created by Barry Barnleitner and hosted on Source Forge, but
 It was completely refactorerd and migrated to Python 3.8+
 
-
 # 🔥 Features
 
-* An OpenOPC Gateway Service (a Windows service providing remote access 
-to the OpenOPC library, which is useful to avoid DCOM issues).
-* Command Line Interface (CLI)
-* Enables you to use OPC Classic with any Platform
-* CLI and Gateway are independent Executables that do not require Python
-* A system check module (allows you to check the health of your system)
-* A free OPC automation wrapper (required DLL file).
-* General documentation with updated procedures (this file).
+- An OpenOPC Gateway Service (a Windows service providing remote access
+  to the OpenOPC library, which is useful to avoid DCOM issues).
+- Command Line Interface (CLI)
+- Enables you to use OPC Classic with any Platform
+- CLI and Gateway are independent Executables that do not require Python
+- A system check module (allows you to check the health of your system)
+- A free OPC automation wrapper (required DLL file).
+- General documentation with updated procedures (this file).
 
 # 🐍 OpenOPC vs OpenOPC 2
 
-Open OPC 2 is based on OpenOPC and should be seen as a successor. If you already have an application that is based on 
+Open OPC 2 is based on OpenOPC and should be seen as a successor. If you already have an application that is based on
 OpenOPC, you can migrate with a minimal effort. Our main motivation to build this new version was to improve the developer
 experience and create a base for other developers that is easier to maintain, test and work with...
 
-* Simpler installation
-* Mostly the same api (but we take the freedom to not be compatible)
-* No memory leak in the OpenOpcService 🎉
-* Python 3.8+ (tested with 3.10)
-* Typings 
-* Pyro5, increased security
-* We added tests 😎
-* Refactoring for increased readablity
-* Nicer CLI
-* Pipy Package 
-
-
+- Simpler installation
+- Mostly the same api (but we take the freedom to not be compatible)
+- No memory leak in the OpenOpcService 🎉
+- Python 3.8+ (tested with 3.10)
+- Typings
+- Pyro5, increased security
+- We added tests 😎
+- Refactoring for increased readablity
+- Nicer CLI
+- Pipy Package
 
 # 🚀 Getting started
-##  Windows local installation
+
+## Windows local installation
 
 The quickest way to start is the cli application. Start your OPC server and use the openopc2.exe cli application for test (no python
-installation required). 
+installation required).
 
-
-
-
-
-Now you know that your OPC server is talking to OpenOPC 2. Then lets get started with python. If you use OpenOPC 2 with 
+Now you know that your OPC server is talking to OpenOPC 2. Then lets get started with python. If you use OpenOPC 2 with
 Python in windows directly you are **limited to a 32bit Python** installation. This is because the dlls of OPC are 32bit.
-If you prefere working with a 64bit Python version you can simply use the With OpenOPC Gateway. 
+If you prefere working with a 64bit Python version you can simply use the With OpenOPC Gateway.
 
 <img src="https://github.com/iterativ/openopc2/raw/develop/doc/assets/WindowsSetup.png" alt="WindowsSetup" width="400"/>
 
-You must install the gbda_aut.dll (in /lib) which is the GrayboxOpcDa wrapper. 
+You must install the gbda_aut.dll (in /lib) which is the GrayboxOpcDa wrapper.
 
 http://gray-box.net/daawrapper.php?lang=en
 
@@ -72,20 +63,17 @@ http://gray-box.net/daawrapper.php?lang=en
 python -m openopc2 servers
 ```
 
-
-
 ## Multi plattform installation
-One of the main benefits of OpenOPC 2 ist the OpenOPC gateway. This enables you to use any modern platform for 
-developting your application. Start the OpenOPC service in the Windows environment where the OPC server is running. 
+
+One of the main benefits of OpenOPC 2 ist the OpenOPC gateway. This enables you to use any modern platform for
+developting your application. Start the OpenOPC service in the Windows environment where the OPC server is running.
 The Service starts a server (Pyro5) that lets you use the OpenOPC2 OpcDaClient on another machine. Due to the magic of
-Pyro (Python Remote Objects) the developer experience and usage of the Library remains the same as if you worke int the 
-local Windows setup. 
-
-
+Pyro (Python Remote Objects) the developer experience and usage of the Library remains the same as if you worke int the
+local Windows setup.
 
 <img src="https://github.com/iterativ/openopc2/raw/develop/doc/assets/LinuxSetup.png" alt="LinuxSetup" width="700"/>
 
-On the Windows Machine open the console as administrator. 
+On the Windows Machine open the console as administrator.
 
 ```shell
 openopcservice install
@@ -93,21 +81,20 @@ openopcservice start
 ```
 
 On your Linux machine
+
 ```
 pip install openopc2
 ```
 
 python
+
 ```python
 from openopc2.da_client import OpcDaClient
-
-
-
 ```
 
-# ⚙️ Configuration 
+# ⚙️ Configuration
 
-The configuration of the OpenOpc 2 libray and the OpenOpcGateway is done via environment variables. 
+The configuration of the OpenOpc 2 libray and the OpenOpcGateway is done via environment variables.
 
 ```
 OPC_CLASS=OPC.Automation
@@ -119,38 +106,37 @@ OPC_MODE=dcom
 OPC_SERVER=Matrikon.OPC.Simulation
 ```
 
-* If they are not set, open a command prompt window to do that by 
-typing:
+- If they are not set, open a command prompt window to do that by
+  typing:
 
 ```
 C:\>set ENV_VAR=VALUE
 C:\>set OPC_GATE_HOST=172.16.4.22    # this is an example
 ```
 
-* Make sure the firewall is allowed to keep the port 7766 open. If in 
-doubt, and you're doing a quick test, just turn off your firewall 
-completely.
+- Make sure the firewall is allowed to keep the port 7766 open. If in
+  doubt, and you're doing a quick test, just turn off your firewall
+  completely.
 
-* For easy testing, make sure an OPC server is installed in your Windows 
-box (i.e. Matrikon OPC Simulation Server).
+- For easy testing, make sure an OPC server is installed in your Windows
+  box (i.e. Matrikon OPC Simulation Server).
 
-* The work environment for testing these changes was a remote MacOs with Window10 64bit host and the Matrikon simulation
-server. 
+- The work environment for testing these changes was a remote MacOs with Window10 64bit host and the Matrikon simulation
+  server.
 
-* Register the OPC automation wrapper ( `gbda_aut.dll` ) by typing this 
-in the command line:
+- Register the OPC automation wrapper ( `gbda_aut.dll` ) by typing this
+  in the command line:
 
 ```shell
 C:\openopc2\lib>regsvr32 gbda_aut.dll
 ```
 
-* If, for any reason, you want to uninstall this file and remove it from 
-your system registry later, type this in the command line:
+- If, for any reason, you want to uninstall this file and remove it from
+  your system registry later, type this in the command line:
 
 ```shell
 C:\openopc2\lib>regsvr32 gbda_aut.dll -u
 ```
-
 
 # CLI
 
@@ -167,40 +153,34 @@ The documentation of the CLI can be found [here](CLI.md)
 <img src="https://github.com/iterativ/openopc2/raw/develop/doc/assets/cli_read.png" alt="WindowsSetup" width="400"/>
 </p>
 
-
 <p>
 <img src="https://github.com/iterativ/openopc2/raw/develop/doc/assets/cli_write.png" alt="WindowsSetup" width="400"/>
 </p>
-
 
 <p>
 <img src="https://github.com/iterativ/openopc2/raw/develop/doc/assets/cli_properties.png" alt="WindowsSetup" width="400"/>
 </p>
 
-
-
 # OpenOPC Gateway
 
-This task can be completed from one of two ways (make sure to have it 
+This task can be completed from one of two ways (make sure to have it
 installed first):
 
-* By clicking the `Start` link on the "OpenOPC Gateway Service" from the 
-"Services" window (Start -> Control Panel -> System and Security -> 
-Administrative Tools).
-* By running the `net start SERVICE` command like this:
+- By clicking the `Start` link on the "OpenOPC Gateway Service" from the
+  "Services" window (Start -> Control Panel -> System and Security ->
+  Administrative Tools).
+- By running the `net start SERVICE` command like this:
 
 ```shell
 C:\openopc2\bin> zzzOpenOPCService
 ```
 
-* If you have problems starting the service, you can also try to start 
-this in "debug" mode:
+- If you have problems starting the service, you can also try to start
+  this in "debug" mode:
 
 ```shell
 C:\openopc2\src>python OpenOPCService.py debug
 ```
-
-
 
 ```shell
 C:\openopc2\>net stop zzzOpenOPCService
@@ -208,40 +188,33 @@ C:\openopc2\>net stop zzzOpenOPCService
 
 ### Configure the way the OpenOPC Gateway Service starts
 
-If you are going to use this service frequently, it would be better to 
+If you are going to use this service frequently, it would be better to
 configure it to start in "automatic" mode. To do this:
 
-* Select the "OpenOPC Gateway Service" from the "Services" window 
-(Start -> Control Panel -> System and Security -> Administrative Tools).
-* Right-click and choose "Properties".
-* Change the startup mode to "Automatic". Click "Apply" and "OK" 
-buttons.
-* Start the service (if not already started).
-
-
-
+- Select the "OpenOPC Gateway Service" from the "Services" window
+  (Start -> Control Panel -> System and Security -> Administrative Tools).
+- Right-click and choose "Properties".
+- Change the startup mode to "Automatic". Click "Apply" and "OK"
+  buttons.
+- Start the service (if not already started).
 
 ## 🙏 Credits
 
 OpenOPC 2 is based on the OpenOPC python library that was originally created by Barry Barnleitner and its many Forks on
-Github. Without the great work of all the contributors, this would not be possible. Contribution is open for everyone. 
+Github. Without the great work of all the contributors, this would not be possible. Contribution is open for everyone.
 
 The authors of the var package are:
 
-
-| Years     |      | Name                | User |
-|-----------|------|---------------------|------|
-| 2008-2012 | 🇺🇸 | Barry Barnreiter    | barry_b@users.sourceforge.net |
-| 2014      | 🇷🇺 | Anton D. Kachalov   | https://github.com/ya-mouse |
-| 2017      | 🇻🇪 | José A. Maita       | https://github.com/joseamaita|
-| 2022      | 🇨🇭 | Lorenz Padberg      | https://github.com/renzop |
-| 2022      | 🇨🇭 | Elia Bieri          | https://github.com/eliabieri |
-
-
-
+| Years     |     | Name              | User                          |
+| --------- | --- | ----------------- | ----------------------------- |
+| 2008-2012 | 🇺🇸  | Barry Barnreiter  | barry_b@users.sourceforge.net |
+| 2014      | 🇷🇺  | Anton D. Kachalov | https://github.com/ya-mouse   |
+| 2017      | 🇻🇪  | José A. Maita     | https://github.com/joseamaita |
+| 2022      | 🇨🇭  | Lorenz Padberg    | https://github.com/renzop     |
+| 2022      | 🇨🇭  | Elia Bieri        | https://github.com/eliabieri  |
 
 ## 📜 License
 
-This software is licensed under the terms of the GNU GPL v2 license plus 
-a special linking exception for portions of the package. This license is 
+This software is licensed under the terms of the GNU GPL v2 license plus
+a special linking exception for portions of the package. This license is
 available in the `LICENSE.txt` file.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ installation required).
 
 Now you know that your OPC server is talking to OpenOPC 2. Then lets get started with python. If you use OpenOPC 2 with
 Python in windows directly you are **limited to a 32bit Python** installation. This is because the dlls of OPC are 32bit.
-If you prefere working with a 64bit Python version you can simply use the With OpenOPC Gateway.
+If you prefer working with a 64bit Python version you can simply use the With OpenOPC Gateway.
 
 <img src="https://github.com/iterativ/openopc2/raw/develop/doc/assets/WindowsSetup.png" alt="WindowsSetup" width="400"/>
 
@@ -63,12 +63,12 @@ http://gray-box.net/daawrapper.php?lang=en
 python -m openopc2 servers
 ```
 
-## Multi plattform installation
+## Multi platform installation
 
-One of the main benefits of OpenOPC 2 ist the OpenOPC gateway. This enables you to use any modern platform for
-developting your application. Start the OpenOPC service in the Windows environment where the OPC server is running.
+One of the main benefits of OpenOPC 2 is the OpenOPC gateway. This enables you to use any modern platform for
+developing your application. Start the OpenOPC service in the Windows environment where the OPC server is running.
 The Service starts a server (Pyro5) that lets you use the OpenOPC2 OpcDaClient on another machine. Due to the magic of
-Pyro (Python Remote Objects) the developer experience and usage of the Library remains the same as if you worke int the
+Pyro (Python Remote Objects) the developer experience and usage of the Library remains the same as if you work in the
 local Windows setup.
 
 <img src="https://github.com/iterativ/openopc2/raw/develop/doc/assets/LinuxSetup.png" alt="LinuxSetup" width="700"/>
@@ -94,7 +94,7 @@ from openopc2.da_client import OpcDaClient
 
 # ⚙️ Configuration
 
-The configuration of the OpenOpc 2 libray and the OpenOpcGateway is done via environment variables.
+The configuration of the OpenOpc 2 library and the OpenOpcGateway is done via environment variables.
 
 ```
 OPC_CLASS=OPC.Automation

--- a/doc/Roadmap.md
+++ b/doc/Roadmap.md
@@ -1,22 +1,25 @@
 Version 1.5
 
 Goals:
+
 - Create a maintainable repository
   - Integration tests coverage 80 %
   - Python 3.8, 3.9
   - Create executables for OpenOPCService and OPC cli
   - Create pypy package
   - remain compatible to 1.3 and 1.2
-  
+
 Known Issues:
+
 - Return Values sometimes List of tuples and sometimes tuple... causes trouble complex code
 - write(tag, include_error=True) returns list of tuples (which should be tuple)
 - too many except: pass this is a very dangerous pattern
 
 Future Goals:
+
 - Proper Logging
 - code  refactoring, reduce complexity increase readablility
-- replace response tuples with named tuples / dataclasses whatever is suitable 
+- replace response tuples with named tuples / dataclasses whatever is suitable
 - improve error handling
 - introduce encrypted protocol for gateway
 - write unittests
@@ -24,7 +27,7 @@ Future Goals:
 - test on multiple python versions and platforms
 
 Far away Goals:
+
 - OPC UA Gateway
 - OPC AE support
 - Rest API
-

--- a/doc/tipps.md
+++ b/doc/tipps.md
@@ -1,5 +1,3 @@
+Start the OpenOPC Gateway locally
 
-
-Start the OpenOPC Gateway locally 
-
-python .\OpenOPCService.py  --foreground
+python .\\OpenOPCService.py  --foreground

--- a/examples/commands.ps1
+++ b/examples/commands.ps1
@@ -1,4 +1,0 @@
-
-
-python -m opc --list --flat -s "Matrikon.OPC.Simulation.1"
-python -m opc  -s "Matrikon.OPC.Simulation.1" --read 'Bucket Brigade.ArrayOfString'


### PR DESCRIPTION
Per comments in https://github.com/iterativ/openopc2/issues/35:
- Corrected typos in `README.md` (found using `codespell`)
- Removed stale `examples/commands.ps1` that duplicated `CLI.md`
- Documented environment variables details in `README.md`
- Updated `README.md` to use `list-servers` instead of `servers`
- Ran `mdformat` on all Markdown files