### PR TITLE
OpenOpcConfig.__init__ args

### DIFF
--- a/openopc2/config.py
+++ b/openopc2/config.py
@@ -3,19 +3,27 @@ from typing import Literal
 
 
 class OpenOpcConfig:
-    def __init__(self):
-        self.OPC_HOST: str = 'localhost'
-        self.OPC_SERVER: str = os.environ.get('OPC_SERVER', 'Matrikon.OPC.Simulation')
-        self.OPC_CLIENT: str = 'OpenOPC'
-        self.OPC_GATEWAY_HOST: str = os.environ.get('OPC_GATE_HOST', '192.168.0.115')
-        self.OPC_GATEWAY_PORT: int = int(os.environ.get('OPC_GATE_PORT', 7766))
-        self.OPC_CLASS: str = os.environ.get('OPC_CLASS', 'Graybox.OPC.DAWrapper')
-        self.OPC_MODE: Literal["GATEWAY", "COM"] = os.environ.get('OPC_MODE', "gateway")
-        self.OPC_TIMEOUT: int = os.environ.get('OPC_TIMEOUT', 1000)
+    def __init__(
+        self,
+        opc_host: str = "localhost",
+        opc_server: str = os.environ.get("OPC_SERVER", "Matrikon.OPC.Simulation"),
+        opc_client: str = "OpenOPC",
+        opc_gateway_host: str = os.environ.get("OPC_GATE_HOST", "192.168.0.115"),
+        opc_gateway_port: int = int(os.environ.get("OPC_GATE_PORT", 7766)),
+        opc_class: str = os.environ.get("OPC_CLASS", "Graybox.OPC.DAWrapper"),
+        opc_mode: Literal["GATEWAY", "COM"] = os.environ.get("OPC_MODE", "gateway"),
+        opc_timeout: int = int(os.environ.get("OPC_TIMEOUT", 1000)),
+    ):
+        self.OPC_HOST = opc_host
+        self.OPC_SERVER = opc_server
+        self.OPC_CLIENT = opc_client
+        self.OPC_GATEWAY_HOST = opc_gateway_host
+        self.OPC_GATEWAY_PORT = opc_gateway_port
+        self.OPC_CLASS = opc_class
+        self.OPC_MODE = opc_mode
+        self.OPC_TIMEOUT = opc_timeout
 
     def print_config(self):
-        print('Open Opc Config:')
+        print("Open Opc Config:")
         for key, value in self.__dict__.items():
-            print(f'{key:20}  : {value}')
-
-
+            print(f"{key:20}  : {value}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,30 @@
+import os
+from unittest import TestCase
+
 from openopc2.config import OpenOpcConfig
+
 
 def test_config():
     open_opc_config = OpenOpcConfig()
     open_opc_config.OPC_SERVER = "Matrikon.OPC.Simulation"
     open_opc_config.OPC_GATEWAY_HOST = "192.168.0.115"
     open_opc_config.OPC_CLASS = "Graybox.OPC.DAWrapper"
-    open_opc_config.OPC_MODE = 'gateway'
+    open_opc_config.OPC_MODE = "gateway"
     return open_opc_config
 
+
+class TestOpenOpcConfig(TestCase):
+    def test_instantiation(self) -> None:
+        # Confirm env vars won't mess up assertions
+        for env_var in ["OPC_SERVER", "OPC_GATE_PORT", "OPC_TIMEOUT"]:
+            self.assertNotIn(env_var, os.environ)
+
+        default_config = OpenOpcConfig()
+        self.assertEquals(default_config.OPC_SERVER, "Matrikon.OPC.Simulation")
+        self.assertIsInstance(default_config.OPC_GATEWAY_PORT, int)
+        self.assertEquals(default_config.OPC_GATEWAY_PORT, 7766)
+        self.assertIsInstance(default_config.OPC_TIMEOUT, int)
+        self.assertEquals(default_config.OPC_TIMEOUT, 1000)
+
+        nondefault_config = OpenOpcConfig(opc_server="Another.Server")
+        self.assertEquals(nondefault_config.OPC_SERVER, "Another.Server")


### PR DESCRIPTION
Adds arguments to `OpenOpcConfig.__init__` such that it can be instantiated in one-line, instead of instantiated then manipulated.

This PR is fully backwards compatible.