### PR TITLE
Fix : parameter order in connect method and allow dynamic host connection

### DIFF
--- a/openopc2/da_client.py
+++ b/openopc2/da_client.py
@@ -147,11 +147,11 @@ class OpcDaClient:
         if self._open_serv is None:
             self.trace = trace
 
-    def connect(self, opc_server=None, opc_host='localhost'):
+    def connect(self, opc_server: str | None = None, opc_host: str = 'localhost'):
         """Connect to the specified OPC server"""
 
         log.info(f"OPC DA OpcDaClient connecting to {opc_server} {opc_host}")
-        self._opc.connect(opc_host, opc_server)
+        self._opc.connect(opc_server, opc_host)
         self.connected = True
 
         # With some OPC servers, the next OPC call immediately after Connect()

--- a/openopc2/da_com.py
+++ b/openopc2/da_com.py
@@ -42,8 +42,8 @@ class OpcCom:
 
     def __init__(self, opc_class: str):
         # TODO: Get browser type (hierarchical etc)
-        self.server: string = None
-        self.host: string = 'localhost'
+        self.server: str | None = None
+        self.host: str = 'localhost'
         self.groups = None
         self.opc_class = opc_class
         self.client_name = None
@@ -69,9 +69,9 @@ class OpcCom:
             pythoncom.CoUninitialize()
             raise OPCError(f'Dispatch: {err} opc_class:"{opc_class}"')
 
-    def connect(self, host: str, server: str):
+    def connect(self, server: str | None, host: str):
         self.server = server
-        self.host = "localhost"
+        self.host = host
         try:
             log.info(f"Connecting OPC Client Com interface: '{self.server}', '{self.host}'")
             self.opc_client.Connect(self.server, self.host)


### PR DESCRIPTION
#67 
If this behavior was implemented intentionally to enforce a 'localhost' connection, feel free to close this request!


- Corrected the parameter order in the connect method of both OpcDaClient and OpcCom classes to ensure the correct sequence of opc_server and opc_host.
- Updated the connect method to allow dynamic host connections instead of defaulting to 'localhost', providing more flexibility in server connections.
- Improved type annotations for better code clarity and type safety. 

Changes:
- Swapped the order of parameters in the connect method to server, host for consistency and correctness.
- Removed the hardcoded 'localhost' assignment, allowing the host to be specified dynamically.
- Enhanced type annotations for opc_server and opc_host parameters. 

Impact:
- These changes ensure that the OPC client can connect to specified servers and hosts correctly, enhancing the flexibility and usability of the library.