### PR TITLE
Pyro Proxy resource allocation fix

### DIFF
--- a/examples/connect_discover_read_tags.py
+++ b/examples/connect_discover_read_tags.py
@@ -51,6 +51,8 @@ def main():
         start = time.time()
         properties = opc_client.properties(tags)
         print(f'{n} {time.time()-start:.3f}s {properties}')
+    opc_client.close() # Remote call OpcDaClient. close()
+    opc_client._pyroRelease() # release the pyro connection
 
 
 if __name__ == '__main__':

--- a/openopc2/gateway_proxy.py
+++ b/openopc2/gateway_proxy.py
@@ -26,9 +26,9 @@ class OpenOpcGatewayProxy:
         register_dict_to_class("exceptions.OPCError", OPCError.dict_to_class)
 
     def get_server_proxy(self):
-        with Pyro5.client.Proxy(f"PYRO:OpenOpcGatewayServer@{self.host}:{self.port}") as open_opc_gateway_server:
-            return open_opc_gateway_server
+        open_opc_gateway_server = Pyro5.client.Proxy(f"PYRO:OpenOpcGatewayServer@{self.host}:{self.port}")
+        return open_opc_gateway_server
 
     def get_opc_da_client_proxy(self):
-        with Pyro5.client.Proxy(f"PYRO:OpcDaClient@{self.host}:{self.port}") as opc_da_client_proxy:
-            return opc_da_client_proxy
+        opc_da_client_proxy =  Pyro5.client.Proxy(f"PYRO:OpcDaClient@{self.host}:{self.port}")
+        return opc_da_client_proxy


### PR DESCRIPTION
1.Remove invalid context management
2.Improve the example and actively release the connection


Although Python has GC that can automatically release resources, when I use it, some resources on the server still cannot be automatically released, causing an exception



```
Traceback(most recent call last):File "openopc2\gateway server.py", line 110,in <module>
File "Pyro5\server.py", line 293,in requestLoop
File "Pyro5\svr threads.py", line 167, in loop
File "Pyro5\svr threads.py", line 205, in events
File "Pyro5\svr threads.py", line 344, in process
File "threading.py", line 852,in startRuntimeError: can't start new thread
```
After checking Pyro5，The problem was solved when I added the code for actively releasing resources on the client side.
All of this PR hopes to improve this example for other project users