### PR TITLE
Update pywin32 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 python = "<3.13,>=3.8"
 pyro5 = "^5.14"
 WMI = { version = "^1.5.1", markers = "sys_platform == 'win32'" }
-pywin32 = { version = "304", markers = "sys_platform == 'win32'" }
+pywin32 = { version = "311", markers = "sys_platform == 'win32'" }
 typer = { extras = ["all"], version = "^0.6.1" }
 rich = "^12.6.0"
 


### PR DESCRIPTION
The package declares support for Python 3.12, but it depends on:

pywin32 = { version = "304", markers = "sys_platform == 'win32'" }

pywin32==304 cannot be installed on Python 3.12, which makes the package impossible to install in a Python 3.12 Windows environment.

Environment
OS: Windows
Python: 3.12
Dependency manager: PDM

**CHANGES:**
- Updated the version for pywin32 from 304 to 311